### PR TITLE
use streaming data source rather than very large buffer

### DIFF
--- a/shootout/benchmarks.go
+++ b/shootout/benchmarks.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -37,10 +36,10 @@ func benchmarkLatency(iters int, copier contender) {
 
 // BenchmarkThroughput runs a high throughput copy to see how implementations compete if
 // not rate limited.
-func benchmarkThroughput(data []byte, buffers []int, copier contender) (results []Measurement) {
+func benchmarkThroughput(count int64, data []byte, buffers []int, copier contender) (results []Measurement) {
 	// Simulate the benchmark for every buffer size
 	for _, buffer := range buffers {
-		source := bytes.NewBuffer(data)
+		source := dataReader(count, data)
 
 		c := NewCheckpoint()
 		copier.Copy(ioutil.Discard, source, buffer)

--- a/shootout/rogerpeppe/bufpipe/pipe.go
+++ b/shootout/rogerpeppe/bufpipe/pipe.go
@@ -37,6 +37,7 @@ type pipe struct {
 }
 
 // Reader holds the read half of a buffered pipe.
+// It is not safe to call methods concurrently on a Reader value.
 type Reader struct {
 	p *pipe
 }
@@ -48,6 +49,12 @@ func (r *Reader) Read(data []byte) (int, error) {
 	return r.p.read(data)
 }
 
+// WriteTo implements io.WriterTo by reading
+// data from the pipe until EOF and writing it to w.
+func (r *Reader) WriteTo(w io.Writer) (int64, error) {
+	return r.p.writeTo(w)
+}
+
 // Close closes the pipe. Subsequent writes to the write end
 // of the pipe will return an io.ErrClosedPipe error.
 func (r *Reader) Close() error {
@@ -55,6 +62,8 @@ func (r *Reader) Close() error {
 }
 
 // Writer holds the write half of a buffered pipe.
+// It is not safe to call methods concurrently on
+// Writer value.
 type Writer struct {
 	p *pipe
 }
@@ -63,6 +72,12 @@ type Writer struct {
 // the data is written or the read half is closed.
 func (w *Writer) Write(data []byte) (int, error) {
 	return w.p.write(data)
+}
+
+// ReadFrom implements io.ReaderFrom by reading
+// all the data from r and writing it to the pipe.
+func (w *Writer) ReadFrom(r io.Reader) (int64, error) {
+	return w.p.readFrom(r)
 }
 
 // Close closes the pipe.
@@ -84,20 +99,56 @@ func New(size int) (*Reader, *Writer) {
 
 func (p *pipe) closeWriter() error {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.wClosed = true
-	p.rwait.Broadcast()
-	p.wwait.Broadcast()
-	p.mu.Unlock()
+	p.rwait.Signal()
+	p.wwait.Signal()
 	return nil
 }
 
 func (p *pipe) closeReader() error {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.rClosed = true
-	p.rwait.Broadcast()
-	p.wwait.Broadcast()
-	p.mu.Unlock()
+	p.rwait.Signal()
+	p.wwait.Signal()
 	return nil
+}
+
+func (p *pipe) readFrom(r io.Reader) (int64, error) {
+	nw := int64(0)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for {
+		if p.rClosed {
+			return nw, io.ErrClosedPipe
+		}
+		buf, _ := p.writeBuf()
+		if len(buf) == 0 {
+			p.wwait.Wait()
+			continue
+		}
+		for len(buf) > 0 {
+			// Unlock the mutex and read directly into
+			// the buffer. This is OK because the available
+			// buffer space can only ever decrease (assuming
+			// there are no other concurrent writers).
+			p.mu.Unlock()
+			n, err := r.Read(buf)
+			p.mu.Lock()
+
+			nw += int64(n)
+			p.p1 += int64(n)
+			p.rwait.Signal()
+			if err != nil {
+				if err == io.EOF {
+					err = nil
+				}
+				return nw, err
+			}
+			buf = buf[n:]
+		}
+	}
 }
 
 func (p *pipe) write(data []byte) (int, error) {
@@ -112,7 +163,7 @@ func (p *pipe) write(data []byte) (int, error) {
 			return nw, io.ErrClosedPipe
 		}
 		n := p.copyFrom(data)
-		p.rwait.Broadcast()
+		p.rwait.Signal()
 		data = data[n:]
 		nw += n
 		if len(data) == 0 {
@@ -140,7 +191,7 @@ func (p *pipe) read(data []byte) (int, error) {
 		n := p.copyInto(data)
 		data = data[n:]
 		if n > 0 {
-			p.wwait.Broadcast()
+			p.wwait.Signal()
 			return n, nil
 		}
 		if p.wClosed {
@@ -150,10 +201,48 @@ func (p *pipe) read(data []byte) (int, error) {
 	}
 }
 
+func (p *pipe) writeTo(w io.Writer) (int64, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	nr := int64(0)
+	for {
+		buf, _ := p.readBuf()
+		if len(buf) == 0 {
+			if p.wClosed {
+				return nr, nil
+			}
+			p.rwait.Wait()
+			continue
+		}
+		// Unlock the mutex and write directly from
+		// the buffer. This is OK because the available
+		// buffered data can only ever increase (assuming
+		// no other concurrent readers)
+		p.mu.Unlock()
+		n, err := w.Write(buf)
+		p.mu.Lock()
+
+		nr += int64(n)
+		p.p0 += int64(n)
+		if err != nil {
+			return nr, err
+		}
+		p.wwait.Signal()
+	}
+}
+
+func (p *pipe) writeBuf() ([]byte, []byte) {
+	return p.bufs(p.p1, p.p0+int64(len(p.buf)))
+}
+
+func (p *pipe) readBuf() ([]byte, []byte) {
+	return p.bufs(p.p0, p.p1)
+}
+
 // copyFrom copies as many bytes as possible from data into the ring
 // buffer and returns the number of bytes copied.
 func (p *pipe) copyFrom(data []byte) int {
-	b0, b1 := p.bufs(p.p1, p.p0+int64(len(p.buf)))
+	b0, b1 := p.writeBuf()
 	n := copy(b0, data)
 	data = data[n:]
 	n += copy(b1, data)
@@ -164,7 +253,7 @@ func (p *pipe) copyFrom(data []byte) int {
 // copyInto copies as many bytes as possible from the ring buffer into
 // data and returns the number of bytes copied.
 func (p *pipe) copyInto(data []byte) int {
-	b0, b1 := p.bufs(p.p0, p.p1)
+	b0, b1 := p.readBuf()
 	n := copy(data, b0)
 	data = data[n:]
 	n += copy(data, b1)

--- a/shootout/rogerpeppe/rogerpeppe.go
+++ b/shootout/rogerpeppe/rogerpeppe.go
@@ -2,12 +2,28 @@ package rogerpeppe
 
 import (
 	"io"
-
 	"github.com/karalabe/bufioprop/shootout/rogerpeppe/bufpipe"
 )
 
-func Copy(w io.Writer, r io.Reader, buffer int) (int64, error) {
-	pr, pw := bufpipe.New(buffer)
+func IOCopy(w io.Writer, r io.Reader, size int) (int64, error) {
+	pr, pw := io.Pipe()
+	done := make(chan error)
+	go func() {
+		_, err := io.Copy(pw, r)
+		pw.Close()
+		done <- err
+	}()
+	n, err0 := io.Copy(w, pr)
+	err1 := <-done
+	if err0 != nil {
+		return n, err0
+	}
+	return n, err1
+}
+
+
+func Copy(w io.Writer, r io.Reader, size int) (int64, error) {
+	pr, pw := bufpipe.New(size)
 	done := make(chan error)
 	go func() {
 		_, err := io.Copy(pw, r)

--- a/shootout/utils.go
+++ b/shootout/utils.go
@@ -23,7 +23,7 @@ type Measurement struct {
 	Bytes    uint64
 }
 
-func (m *Measurement) Throughput(size int) float64 {
+func (m *Measurement) Throughput(size int64) float64 {
 	return float64(size) / (1024 * 1024) / m.Duration.Seconds()
 }
 


### PR DESCRIPTION
This means we're not allocating enormous in-memory buffers when we
don't need to. Note that the new dataReader returns some some bytes
as well as io.EOF, which exposes a bug in bufioprop.Copy.

Also implement ReadFrom and WriteTo in bufpipe and add rogerpeppe.IOCopy.

```
Manually disabled contenders:
       ncw.Copy: deadlock in latency benchmark.
------------------------------------------------

High throughput tests:
        io.Copy: test passed.
 [!] bufio.Copy: data length mismatch: have 133999866, want 134217728.
rogerpeppe.Copy: test passed.
rogerpeppe.IOCopy: test passed.
mattharden.Copy: test passed.
     yiyus.Copy: corrupt data on the output.
 egonelbre.Copy: test passed.
      jnml.Copy: test passed.
 bakulshah.Copy: panic.
------------------------------------------------

Stable input, stable output shootout:
        io.Copy:   3.270891077s   9.783267 mbps   119 allocs     40216 B
rogerpeppe.Copy:   3.246096777s   9.857993 mbps   118 allocs  12590464 B
rogerpeppe.IOCopy:   3.279888004s   9.756431 mbps   109 allocs     72464 B
mattharden.Copy:   5.766680025s   5.549120 mbps    97 allocs  25171992 B
 egonelbre.Copy:   3.254862235s   9.831445 mbps   157 allocs  12592928 B
      jnml.Copy:   3.253404368s   9.835851 mbps  8550 allocs   1460448 B

Stable input, bursty output shootout:
        io.Copy:   5.971070416s   5.359173 mbps    81 allocs     37888 B
rogerpeppe.Copy:   3.943562577s   8.114490 mbps    78 allocs  24121920 B
rogerpeppe.IOCopy:   5.994643857s   5.338099 mbps    97 allocs  11605936 B
 egonelbre.Copy:   3.944859063s   8.111823 mbps    98 allocs  23074896 B
      jnml.Copy:   3.987245086s   8.025591 mbps 10583 allocs  20334992 B

Bursty input, stable output shootout:
rogerpeppe.Copy:   3.139678998s  10.192125 mbps    74 allocs  24121664 B
 egonelbre.Copy:    3.14634003s  10.170547 mbps    95 allocs  24122784 B
      jnml.Copy:   3.255125514s   9.830650 mbps 10846 allocs  11945424 B
------------------------------------------------

Latency benchmarks (GOMAXPROCS = 1):
rogerpeppe.Copy: 3.262µs      24 allocs      2288 B.
 egonelbre.Copy: 3.249µs      29 allocs      2368 B.
      jnml.Copy: 3.78µs 2000031 allocs  64002720 B.

Latency benchmarks (GOMAXPROCS = 8):
rogerpeppe.Copy: 8.944µs   16947 allocs   1085328 B.
 egonelbre.Copy: 8.59µs  108200 allocs   6926208 B.
      jnml.Copy: 13.423µs 2039896 allocs  66554320 B.

Throughput (GOMAXPROCS = 1) (256 MB):

+-----------------+--------+---------+----------+---------+----------+
|   THROUGHPUT    |  333   |  4155   |  65359   | 1048559 | 16777301 |
+-----------------+--------+---------+----------+---------+----------+
| rogerpeppe.Copy | 337.34 | 3380.44 | 10855.73 | 9202.67 |  6220.72 |
| egonelbre.Copy  | 367.23 | 3574.82 | 10857.49 | 8420.82 |  4673.30 |
| jnml.Copy       | 319.81 | 3283.92 |  5562.05 | 4060.81 |  3739.85 |
+-----------------+--------+---------+----------+---------+----------+

+-----------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
|  ALLOCS/BYTES   |          333          |         4155          |         65359         |        1048559        |       16777301        |
+-----------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
| rogerpeppe.Copy | (      14 /     1248) | (      13 /     5440) | (      12 /    66080) | (      12 /  1049120) | (      13 / 16786016) |
| egonelbre.Copy  | (      22 /     1536) | (      21 /     5504) | (      21 /    66432) | (      21 /  1049472) | (      21 / 16786304) |
| jnml.Copy       | (  806126 / 25796544) | (   65549 /  2101824) | (   65564 /  2159792) | (   65804 /  3153136) | (   69645 / 19055088) |
+-----------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+

Throughput (GOMAXPROCS = 8) (256 MB):

+-----------------+--------+---------+---------+---------+----------+
|   THROUGHPUT    |  333   |  4155   |  65359  | 1048559 | 16777301 |
+-----------------+--------+---------+---------+---------+----------+
| rogerpeppe.Copy |  90.18 |  876.38 | 4122.45 | 5575.73 |  3091.37 |
| egonelbre.Copy  | 186.98 | 1553.11 | 4749.35 | 6146.23 |  4770.75 |
| jnml.Copy       |  95.80 |  764.53 | 4048.35 | 4023.22 |  4066.82 |
+-----------------+--------+---------+---------+---------+----------+

+-----------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
|  ALLOCS/BYTES   |          333          |         4155          |         65359         |        1048559        |       16777301        |
+-----------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
| rogerpeppe.Copy | (      13 /      960) | (      14 /     5504) | (      13 /    66144) | (      13 /  1049184) | (      15 / 16786368) |
| egonelbre.Copy  | (     413 /    26784) | (     147 /    13568) | (      55 /    68608) | (      41 /  1050752) | (      65 / 16789120) |
| jnml.Copy       | (  806129 / 25796960) | (   65550 /  2102112) | (   65564 /  2159792) | (   65804 /  3153136) | (   66077 /  4444832) |
+-----------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+
```
